### PR TITLE
📝 Nuxt proxy documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,34 @@ yarn add nuxt-jsonapi # or npm install nuxt-jsonapi
 export default {
   modules: ['nuxt-jsonapi'],
 
-  jsonapi: {
+  jsonApi: {
+    baseUrl: 'http://www.example.com/api'
+    /* other module options */
+  }
+}
+```
+
+4. If you use it with Nuxt proxy and SSR mode, do not add `axiosOptions: { proxy: true }`, and keep the axios module.
+
+```js
+export default {
+  modules: ['@nuxtjs/axios', '@nuxtjs/proxy', 'nuxt-jsonapi'],
+
+  axios: {
+    baseURL: '/api', // Attention: URL in capital case
+    proxy: true,
+  },
+
+  proxy: {
+    '/api': {
+      target: 'http://api.example.com',
+      pathRewrite: {
+        '^/api': '/api/v1', // For example
+      },
+    },
+  },
+
+  jsonApi: {
     baseUrl: 'http://www.example.com/api'
     /* other module options */
   }
@@ -71,11 +98,23 @@ You can access the client through `this.$jsonApi` or `context.$jsonapi`.
 
 **Example:**
 
+- AsyncData hook :
+
+```js
+async asyncData({ $jsonApi }) {
+    articles = await $jsonApi.get('/article')
+
+    return {
+        articles,
+    }
+  }
+```
+
+- Fetch hook
+
 ```js
 async fetch() {
-    this.articles = await this.$jsonApi.get('/article').then(articles => {
-      return articles.data
-    })
+    this.articles = await this.$jsonApi.get('/article')
   }
 ```
 

--- a/example/pages/index.vue
+++ b/example/pages/index.vue
@@ -24,9 +24,7 @@ export default {
     }
   },
   async fetch() {
-    this.articles = await this.$jsonApi.get('/article').then(articles => {
-      return articles.data
-    })
+    this.articles = await this.$jsonApi.get('/article')
   }
 }
 </script>


### PR DESCRIPTION
Hey there!

I had troubles using the module as I was using NuxtJS Proxy module. So I allowed myself to edit the readme !
I also changed in the nuxt.js.config `jsonapi: {}` to `jsonApi: {}`.
I also wanted to change `baseUrl` to `baseURL`... But did not. I will let you manage this point. Just know that the Axios module uses `baseURL` (https://github.com/axios/axios#request-config).
And removed the then() from the example. Async / Await should not use then / catch (if you want to, you should use a promise).
And added asyncData hook example (just for fun :D ).

Do not hesitate to ask me to edit my commit if required.

Thanks for your work :) 

R