### PR TITLE
🐛 pluralize option is ignored

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -6,7 +6,7 @@ export default function (ctx, inject) {
     <% if (options.headers) { %>headers: <%= JSON.stringify(options.headers, null, 6) %>,<% } %>
     <% if (options.camelCaseTypes) { %>camelCaseTypes: <%= options.camelCaseTypes %>,<% } %>
     <% if (options.resourceCase) { %>resourceCase: '<%= options.resourceCase %>',<% } %>
-    <% if (options.pluralize) { %>pluralize: <%= options.pluralize %>,<% } %>
+    <% if (options.pluralize !== undefined) { %>pluralize: <%= options.pluralize %>,<% } %>
     <% if (options.timeout) { %>timeout: <%= options.timeout %>,<% } %>
     <% if (options.axiosOptions) { %>axiosOptions: <%= serialize(options.axiosOptions) %>,<% } %>
   }


### PR DESCRIPTION
Hey!
Pluralize option is a boolean with a default value to true. The current condition is:
`if (options.pluralize)`
So if pluralize is defined to 0 or false ; pluralize is ignored and not added to Kitsu options.