### PR TITLE
feat: change baseUrl option to baseURL

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ yarn add nuxt-jsonapi # or npm install nuxt-jsonapi
     [
       'nuxt-jsonapi',
       {
-        baseUrl: 'http://www.example.com/api'
+        baseURL: 'http://www.example.com/api'
         /* other module options */
       }
     ]
@@ -42,14 +42,14 @@ yarn add nuxt-jsonapi # or npm install nuxt-jsonapi
 }
 ```
 
-3. If you didn't pass options with step #2, add a `jsonapi` object to your `nuxt.config.js` to configure module options:
+3. If you didn't pass options with step #2, add a `jsonApi` object to your `nuxt.config.js` to configure module options:
 
 ```js
 export default {
   modules: ['nuxt-jsonapi'],
 
-  jsonapi: {
-    baseUrl: 'http://www.example.com/api'
+  jsonApi: {
+    baseURL: 'http://www.example.com/api'
     /* other module options */
   }
 }
@@ -59,7 +59,7 @@ export default {
 
 ## ❗ Important
 
-If you do not specify a `baseUrl` option, a default `/jsonapi` URL will be used. **This is almost certainly not what you want** so be sure it is set correctly.
+If you do not specify a `baseURL` option, a default `/jsonapi` URL will be used. **This is almost certainly not what you want** so be sure it is set correctly.
 
 ---
 

--- a/example/nuxt.config.js
+++ b/example/nuxt.config.js
@@ -6,6 +6,8 @@ module.exports = {
   srcDir: __dirname,
   modules: [{ handler: require('../') }],
   jsonApi: {
+    baseURL: 'http://localhost:9999/jsonapi',
+    // @deprecated since version 0.1.0
     baseUrl: 'http://localhost:9999/jsonapi'
   }
 }

--- a/lib/module.js
+++ b/lib/module.js
@@ -25,22 +25,35 @@ module.exports = function (moduleOptions) {
     (nuxt.options.server && nuxt.options.server.port) ||
     3000
 
+  /**
+   * @deprecated since version 0.1.0
+   */
+  if (options.baseUrl) {
+    options.baseURL = options.baseUrl
+
+    console.log(
+      `${chalk.yellow(
+        'The "baseUrl" option has been deprecated since v0.1.0 and will be removed in v1.0. Please update your configuration to use the "baseURL" (URL in all uppercase) option instead.'
+      )}`
+    )
+  }
+
   // ENV overrides.
   if (process.env.JSON_API_ENDPOINT) {
-    options.baseUrl = process.env.JSON_API_ENDPOINT
+    options.baseURL = process.env.JSON_API_ENDPOINT
   }
 
   // If no endpoint is defined, use the default server url + /jsonapi.
-  if (!options.baseUrl) {
-    options.baseUrl = `http://${defaultHost}:${defaultPort}/jsonapi`
+  if (!options.baseURL) {
+    options.baseURL = `http://${defaultHost}:${defaultPort}/jsonapi`
   }
 
   // Print the JSON:API endpoint url in the CLI.
   nuxt.hook('listen', function () {
-    if (options.baseUrl) {
+    if (options.baseURL) {
       nuxt.options.cli.badgeMessages.push(
-        `${chalk.bold('JSON:API Endpoint:')} ${chalk.underline.yellow(
-          options.baseUrl
+        `${chalk.bold('JSON:API Endpoint:')} ${chalk.underline.green(
+          options.baseURL
         )}`
       )
     }

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -2,7 +2,7 @@ import Kitsu from 'kitsu'
 
 export default function (ctx, inject) {
   const kitsuOptions = {
-    baseURL: '<%= options.baseUrl %>',
+    baseURL: '<%= options.baseURL %>',
     <% if (options.headers) { %>headers: <%= JSON.stringify(options.headers, null, 6) %>,<% } %>
     <% if (options.camelCaseTypes !== undefined) { %>camelCaseTypes: <%= options.camelCaseTypes %>,<% } %>
     <% if (options.resourceCase) { %>resourceCase: '<%= options.resourceCase %>',<% } %>

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -25,12 +25,12 @@ describe('module', () => {
   })
 
   test('should show cli message', () => {
-    const { baseUrl } = nuxt.options.jsonApi
+    const { baseURL } = nuxt.options.jsonApi
     const { badgeMessages } = nuxt.options.cli
 
     expect(badgeMessages).toContainEqual(
       expect.stringContaining('JSON:API Endpoint')
     )
-    expect(badgeMessages).toContainEqual(expect.stringContaining(baseUrl))
+    expect(badgeMessages).toContainEqual(expect.stringContaining(baseURL))
   })
 })


### PR DESCRIPTION
Switch to baseURL config property name to align with Kitsu and Axios naming.

closes #14