### PR TITLE
fix: switch to separate type import for plugin

### DIFF
--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -1,6 +1,7 @@
 import Kitsu from 'kitsu'
 import type KitsuTypes from 'kitsu'
-import { defineNuxtPlugin, useRuntimeConfig, Plugin } from '#app'
+import { defineNuxtPlugin, useRuntimeConfig } from '#app'
+import type { Plugin } from '#app'
 
 const plugin: Plugin<{ jsonApi: KitsuTypes }> = defineNuxtPlugin(nuxtApp => {
   const { jsonApi: options } = useRuntimeConfig().public


### PR DESCRIPTION
This will help with compatibility with Nuxt v3.8.0 https://github.com/nuxt/nuxt/releases/tag/v3.8.0