### PR TITLE
chore: indicate compatibility with Nuxt 5

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -25,7 +25,7 @@ export default defineNuxtModule<ModuleOptions>({
     version,
     configKey: 'jsonApi',
     compatibility: {
-      nuxt: '^3.0.0',
+      nuxt: '>=3.0.0',
     },
   },
   defaults: {


### PR DESCRIPTION
With Nuxt 5 about to be released, this updates the module compatibility definition to allow it to be installed on Nuxt v5. (Otherwise Nuxt will indicate the module might not be compatible.)

You can follow this and other changes in https://github.com/nuxt/nuxt/issues/27613 - please feel free to provide feedback as well!